### PR TITLE
Major Refactor

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -46,13 +46,12 @@ def get_checkin_data(number, first, last):
     return r.json()['checkInViewReservationPage']
 
 def checkin(number, first, last):
-    success = False
     attempts = 0
     data = {}
     # You might ask yourself, "Why the hell does this exist?"
     # Basically, there sometimes appears a "hiccup" in Southwest where things
     # aren't exactly available 24-hours before, so we try a few times
-    while not success:
+    while True:
         # get checkin data from first api call
         data = get_checkin_data(number, first, last)
         if 'httpStatusCode' in data and data['httpStatusCode'] in ['NOT_FOUND', 'BAD_REQUEST', 'FORBIDDEN']:
@@ -62,7 +61,7 @@ def checkin(number, first, last):
                 sys.exit("Unable to get checkin data, killing self")
             time.sleep(CHECKIN_INTERVAL_SECONDS)
             continue
-        success = True
+        break
 
     info_needed = data['_links']['checkIn']
     url = "{}mobile-air-operations{}".format(BASE_URL, info_needed['href'])

--- a/checkin.py
+++ b/checkin.py
@@ -34,55 +34,43 @@ MAX_ATTEMPTS = 40
 # Pulled from proxying the Southwest iOS App
 headers = {'Host': 'mobile.southwest.com', 'Content-Type': 'application/json', 'X-API-Key': API_KEY, 'X-User-Experience-Id': USER_EXPERIENCE_KEY, 'Accept': '*/*'}
 
-def lookup_existing_reservation(number, first, last):
-    # Find our existing record
-    url = "{}mobile-misc/v1/mobile-misc/page/view-reservation/{}?first-name={}&last-name={}".format(BASE_URL, number, first, last)
-    r = requests.get(url, headers=headers)
-    return r.json()['viewReservationViewPage']
-
-def get_checkin_data(number, first, last):
-    url = "{}mobile-air-operations/v1/mobile-air-operations/page/check-in/{}?first-name={}&last-name={}".format(BASE_URL, number, first, last)
-    r = requests.get(url, headers=headers)
-    return r.json()['checkInViewReservationPage']
-
-def checkin(number, first, last):
+# You might ask yourself, "Why the hell does this exist?"
+# Basically, there sometimes appears a "hiccup" in Southwest where things
+# aren't exactly available 24-hours before, so we try a few times
+def safe_request(url, body=None):
     attempts = 0
-    data = {}
-    # You might ask yourself, "Why the hell does this exist?"
-    # Basically, there sometimes appears a "hiccup" in Southwest where things
-    # aren't exactly available 24-hours before, so we try a few times
     while True:
-        # get checkin data from first api call
-        data = get_checkin_data(number, first, last)
+        if body is not None:
+            r = requests.post(url, headers=headers, json=body)
+        else:
+            r = requests.get(url, headers=headers)
+        data = r.json()
         if 'httpStatusCode' in data and data['httpStatusCode'] in ['NOT_FOUND', 'BAD_REQUEST', 'FORBIDDEN']:
             attempts += 1
             print(data['message'])
             if attempts > MAX_ATTEMPTS:
-                sys.exit("Unable to get checkin data, killing self")
+                sys.exit("Unable to get data, killing self")
             time.sleep(CHECKIN_INTERVAL_SECONDS)
             continue
-        break
+        return data
 
+def lookup_existing_reservation(number, first, last):
+    # Find our existing record
+    url = "{}mobile-misc/v1/mobile-misc/page/view-reservation/{}?first-name={}&last-name={}".format(BASE_URL, number, first, last)
+    data = safe_request(url)
+    return data['viewReservationViewPage']
+
+def get_checkin_data(number, first, last):
+    url = "{}mobile-air-operations/v1/mobile-air-operations/page/check-in/{}?first-name={}&last-name={}".format(BASE_URL, number, first, last)
+    data = safe_request(url)
+    return data['checkInViewReservationPage']
+
+def checkin(number, first, last):
+    data = get_checkin_data(number, first, last)
     info_needed = data['_links']['checkIn']
     url = "{}mobile-air-operations{}".format(BASE_URL, info_needed['href'])
-    while True:
-        print("Attempting check-in...")
-        r = requests.post(url, headers=headers, json=info_needed['body'])
-        body = r.json()
-
-        if 'httpStatusCode' in body and body['httpStatusCode'] in ['NOT_FOUND', 'BAD_REQUEST', 'FORBIDDEN']:
-            attempts += 1
-            print(body['message'])
-            if attempts > MAX_ATTEMPTS:
-                sys.exit("Max number of attempts exceeded, killing self")
-            print("Attempt {}, waiting {} seconds before retrying...".format(attempts, CHECKIN_INTERVAL_SECONDS))
-            time.sleep(CHECKIN_INTERVAL_SECONDS)
-        else:
-            # Spit out info about boarding number
-            for flight in body['checkInConfirmationPage']['flights']:
-                for doc in flight['passengers']:
-                    print("{} got {}{}!".format(doc['name'], doc['boardingGroup'], doc['boardingPosition']))
-            break
+    print("Attempting check-in...")
+    return safe_request(url, info_needed['body'])['checkInConfirmationPage']
 
 def schedule_checkin(flight_time, number, first, last):
     checkin_time = flight_time - timedelta(days=1)
@@ -96,16 +84,12 @@ def schedule_checkin(flight_time, number, first, last):
         h, m = divmod(m, 60)
         print("Too early to check in.  Waiting {} hours, {} minutes, {} seconds".format(trunc(h), trunc(m), s))
         time.sleep(delta)
-    checkin(number, first, last)
+    data = checkin(number, first, last)
+    for flight in data['flights']:
+        for doc in flight['passengers']:
+            print("{} got {}{}!".format(doc['name'], doc['boardingGroup'], doc['boardingPosition']))
 
-if __name__ == '__main__':
-    arguments = docopt(__doc__, version='Southwest Checkin 0.2')
-
-    # work work
-    reservation_number = arguments['CONFIRMATION_NUMBER']
-    first_name = arguments['FIRST_NAME']
-    last_name = arguments['LAST_NAME']
-
+def auto_checkin(reservation_number, first_name, last_name):
     body = lookup_existing_reservation(reservation_number, first_name, last_name)
 
     # setup a geocoder
@@ -115,7 +99,6 @@ if __name__ == '__main__':
     # Get our local current time
     now = datetime.now(pytz.utc).astimezone(get_localzone())
     tomorrow = now + timedelta(days=1)
-    date = now
 
     # find all eligible legs for checkin
     for leg in body['bounds']:
@@ -127,3 +110,13 @@ if __name__ == '__main__':
             # found a flight for checkin!
             print("Flight information found, departing {} at {}".format(airport, date.strftime('%b %d %I:%M%p')))
             schedule_checkin(date, reservation_number, first_name, last_name)
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__, version='Southwest Checkin 0.2')
+
+    # work work
+    reservation_number = arguments['CONFIRMATION_NUMBER']
+    first_name = arguments['FIRST_NAME']
+    last_name = arguments['LAST_NAME']
+
+    auto_checkin(reservation_number, first_name, last_name)

--- a/checkin.py
+++ b/checkin.py
@@ -83,9 +83,7 @@ def checkin(number, first, last):
             for flight in body['checkInConfirmationPage']['flights']:
                 for doc in flight['passengers']:
                     print("{} got {}{}!".format(doc['name'], doc['boardingGroup'], doc['boardingPosition']))
-            # clean exit
-            sys.exit(0)
-    # end checkin method
+            break
 
 def schedule_checkin(flight_time, number, first, last):
     checkin_time = flight_time - timedelta(days=1)

--- a/checkin.py
+++ b/checkin.py
@@ -105,7 +105,9 @@ def auto_checkin(reservation_number, first_name, last_name):
         # calculate departure for this leg
         airport = "{}, {}".format(leg['departureAirport']['name'], leg['departureAirport']['state'])
         takeoff = "{} {}".format(leg['departureDate'], leg['departureTime'])
-        date = datetime.strptime(takeoff, '%Y-%m-%d %H:%M').replace(tzinfo=g.timezone(g.geocode(airport).point))
+        point = g.geocode(airport).point
+        airport_tz = g.timezone(point)
+        date = airport_tz.localize(datetime.strptime(takeoff, '%Y-%m-%d %H:%M'))
         if date > now:
             # found a flight for checkin!
             print("Flight information found, departing {} at {}".format(airport, date.strftime('%b %d %I:%M%p')))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 datetime
+docopts
 geopy
 python-dateutil
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 datetime
+geopy
 python-dateutil
 pytz
 requests


### PR DESCRIPTION
### Thanks Southwest!

Sometime between Thanksgiving and Christmas this year Southwest changed their API and broke the existing script.  The cat and mouse game lives on!

Fixes #9, #10, and #11.

### Changes

#### New Features

**Round-trip checkins!**  Sadly I haven't been able to test this thoroughly, as I fly with a [Companion Pass](https://www.southwest.com/rapidrewards/tiers-more-companion-pass) which results in having unique confirmation numbers each direction, but the script should now [check you in for all legs of a trip](https://github.com/pyro2927/SouthwestCheckin/blob/thanks_southwest/checkin.py#L104).

**DocOpt**  I added [docopt](https://github.com/docopt/docopt) to hopefully make the script more user friendly.

#### API Endpoints

The old API worked off endpoints like <https://mobile.southwest.com/api/extensions/v1/mobile/reservations/record-locator/>.  The one one uses <https://mobile.southwest.com/api/mobile-misc/v1/mobile-misc/page/view-reservation/>.

#### Less Friendly Endpoints

The previous endpoint (`.../reservations/record-locator`) was nice, in that it would return an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) date for when the flight was.  With the new API, they only return a date and time sans-timezone.  Because of this I've had to incorporate the [`geopy`](https://github.com/geopy/geopy) library in order to calculate what the timezone of the airport is.

##### Fun Bug

Apparently `datetime`'s `.replace(tzinfo=)` method does not work the same as `timezone`'s `.localize`.  When refactoring this project, I found that non-standard timezones would have non-half-hour-rounded offsets, ie: `America/Los_Angeles` has an offset of `-07:53`.  Most people, as well as Southwest, honor the localized/less-accurate offsets.

```bash
$ cat test.py
from datetime import datetime
from pytz import timezone, utc

tz = timezone('America/Los_Angeles')
date = datetime.now(utc)
print("Replace:  {}".format(date.replace(tzinfo=tz)))
print("Localize: {}".format(tz.localize(date.replace(tzinfo=None))))

$ python ./test.py
Replace:  2017-12-29 03:24:32.410543-07:53
Localize: 2017-12-29 03:24:32.410543-08:00
```