### PR TITLE
enable verbose output

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,3 +5,6 @@ plugins:
     checks:
       E501:
         enabled: false
+      argument-count:
+        config:
+          threshold: 5

--- a/checkin.py
+++ b/checkin.py
@@ -46,8 +46,8 @@ def schedule_checkin(flight_time, reservation):
             print("{} got {}{}!".format(doc['name'], doc['boardingGroup'], doc['boardingPosition']))
 
 
-def auto_checkin(reservation_number, first_name, last_name, verbose, notify=[]):
-    r = Reservation(reservation_number, first_name, last_name, verbose, notify)
+def auto_checkin(reservation_number, first_name, last_name, notify=[], verbose=False):
+    r = Reservation(reservation_number, first_name, last_name, notify, verbose)
     body = r.lookup_existing_reservation()
 
     # Get our local current time
@@ -101,7 +101,7 @@ if __name__ == '__main__':
         notifications.append({'mediaType': 'SMS', 'phoneNumber': mobile})
 
     try:
-        auto_checkin(reservation_number, first_name, last_name, verbose, notifications)
+        auto_checkin(reservation_number, first_name, last_name, notifications, verbose)
     except KeyboardInterrupt:
         print("Ctrl+C detected, canceling checkin")
         sys.exit()

--- a/checkin.py
+++ b/checkin.py
@@ -46,8 +46,8 @@ def schedule_checkin(flight_time, reservation):
             print("{} got {}{}!".format(doc['name'], doc['boardingGroup'], doc['boardingPosition']))
 
 
-def auto_checkin(reservation_number, first_name, last_name, notify=[]):
-    r = Reservation(reservation_number, first_name, last_name, notify)
+def auto_checkin(reservation_number, first_name, last_name, verbose, notify=[]):
+    r = Reservation(reservation_number, first_name, last_name, verbose, notify)
     body = r.lookup_existing_reservation()
 
     # Get our local current time
@@ -85,12 +85,13 @@ def auto_checkin(reservation_number, first_name, last_name, notify=[]):
 
 if __name__ == '__main__':
 
-    arguments = docopt(__doc__, version='Southwest Checkin 1')
+    arguments = docopt(__doc__, version='Southwest Checkin 2')
     reservation_number = arguments['CONFIRMATION_NUMBER']
     first_name = arguments['FIRST_NAME']
     last_name = arguments['LAST_NAME']
     email = arguments['--email']
     mobile = arguments['--mobile']
+    verbose = arguments['--verbose']
 
     # build out notifications
     notifications = []
@@ -100,7 +101,7 @@ if __name__ == '__main__':
         notifications.append({'mediaType': 'SMS', 'phoneNumber': mobile})
 
     try:
-        auto_checkin(reservation_number, first_name, last_name, notifications)
+        auto_checkin(reservation_number, first_name, last_name, verbose, notifications)
     except KeyboardInterrupt:
         print("Ctrl+C detected, canceling checkin")
         sys.exit()

--- a/southwest/southwest.py
+++ b/southwest/southwest.py
@@ -11,7 +11,7 @@ MAX_ATTEMPTS = 40
 
 class Reservation():
 
-    def __init__(self, number, first, last, verbose, notifications=[]):
+    def __init__(self, number, first, last, notifications=[], verbose=False):
         self.number = number
         self.first = first
         self.last = last

--- a/southwest/southwest.py
+++ b/southwest/southwest.py
@@ -1,5 +1,6 @@
 from time import sleep
 import requests
+import json
 import sys
 import uuid
 
@@ -10,11 +11,12 @@ MAX_ATTEMPTS = 40
 
 class Reservation():
 
-    def __init__(self, number, first, last, notifications=[]):
+    def __init__(self, number, first, last, verbose, notifications=[]):
         self.number = number
         self.first = first
         self.last = last
         self.notifications = notifications
+        self.verbose = verbose
 
     @staticmethod
     def generate_headers():
@@ -45,11 +47,16 @@ class Reservation():
                 data = r.json()
                 if 'httpStatusCode' in data and data['httpStatusCode'] in ['NOT_FOUND', 'BAD_REQUEST', 'FORBIDDEN']:
                     attempts += 1
-                    print(data['message'])
+                    if not self.verbose:
+                        print(data['message'])
+                    else:
+                        print(json.dumps(data, indent=2))
                     if attempts > MAX_ATTEMPTS:
                         sys.exit("Unable to get data, killing self")
                     sleep(CHECKIN_INTERVAL_SECONDS)
                     continue
+                if self.verbose:
+                    print(json.dumps(data, indent=2))
                 return data
         except ValueError:
             # Ignore responses with no json data in body

--- a/southwest/southwest.py
+++ b/southwest/southwest.py
@@ -50,12 +50,14 @@ class Reservation():
                     if not self.verbose:
                         print(data['message'])
                     else:
+                        print(r.headers)
                         print(json.dumps(data, indent=2))
                     if attempts > MAX_ATTEMPTS:
                         sys.exit("Unable to get data, killing self")
                     sleep(CHECKIN_INTERVAL_SECONDS)
                     continue
                 if self.verbose:
+                    print(r.headers)
                     print(json.dumps(data, indent=2))
                 return data
         except ValueError:


### PR DESCRIPTION
--verbose switch already existed, but did nothing.

This change causes checkin to print out the raw JSON it receives from southwest, if --verbose is selected.