### PR TITLE
Remove email/sms boarding pass options

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -2,15 +2,13 @@
 """Southwest Checkin.
 
 Usage:
-  checkin.py CONFIRMATION_NUMBER FIRST_NAME LAST_NAME [--email=<email_addr> | --mobile=<phone_num>] [-v | --verbose]
+  checkin.py CONFIRMATION_NUMBER FIRST_NAME LAST_NAME [-v | --verbose]
   checkin.py (-h | --help)
   checkin.py --version
 
 Options:
   -h --help     Show this screen.
   -v --verbose  Show debugging information.
-  --email=<email_addr>  Email address where notification will be sent to.
-  --mobile=<phone_num>  Phone number where text notification will be sent to.
   --version     Show version.
 
 """
@@ -50,8 +48,8 @@ def schedule_checkin(flight_time, reservation):
             print("{} got {}{}!".format(doc['name'], doc['boardingGroup'], doc['boardingPosition']))
 
 
-def auto_checkin(reservation_number, first_name, last_name, notify=[], verbose=False):
-    r = Reservation(reservation_number, first_name, last_name, notify, verbose)
+def auto_checkin(reservation_number, first_name, last_name, verbose=False):
+    r = Reservation(reservation_number, first_name, last_name, verbose)
     body = r.lookup_existing_reservation()
 
     # Get our local current time
@@ -89,23 +87,14 @@ def auto_checkin(reservation_number, first_name, last_name, notify=[], verbose=F
 
 if __name__ == '__main__':
 
-    arguments = docopt(__doc__, version='Southwest Checkin 2')
+    arguments = docopt(__doc__, version='Southwest Checkin 3')
     reservation_number = arguments['CONFIRMATION_NUMBER']
     first_name = arguments['FIRST_NAME']
     last_name = arguments['LAST_NAME']
-    email = arguments['--email']
-    mobile = arguments['--mobile']
     verbose = arguments['--verbose']
 
-    # build out notifications
-    notifications = []
-    if email is not None:
-        notifications.append({'mediaType': 'EMAIL', 'emailAddress': email})
-    if mobile is not None:
-        notifications.append({'mediaType': 'SMS', 'phoneNumber': mobile})
-
     try:
-        auto_checkin(reservation_number, first_name, last_name, notifications, verbose)
+        auto_checkin(reservation_number, first_name, last_name, verbose)
     except KeyboardInterrupt:
         print("Ctrl+C detected, canceling checkin")
         sys.exit()

--- a/southwest/__init__.py
+++ b/southwest/__init__.py
@@ -1,3 +1,2 @@
-from .notifications import Notifications
 from .southwest import Reservation
 from .openflights import timezone_for_airport

--- a/southwest/notifications.py
+++ b/southwest/notifications.py
@@ -1,8 +1,0 @@
-class Notifications:
-    @staticmethod
-    def Phone(number):
-        return {'mediaType': 'SMS', 'phoneNumber': number}
-
-    @staticmethod
-    def Email(email_address):
-        return {'mediaType': 'EMAIL', 'emailAddress': email_address}

--- a/southwest/southwest.py
+++ b/southwest/southwest.py
@@ -11,11 +11,10 @@ MAX_ATTEMPTS = 40
 
 class Reservation():
 
-    def __init__(self, number, first, last, notifications=[], verbose=False):
+    def __init__(self, number, first, last, verbose=False):
         self.number = number
         self.first = first
         self.last = last
-        self.notifications = notifications
         self.verbose = verbose
 
     @staticmethod
@@ -88,26 +87,4 @@ class Reservation():
         url = "{}mobile-air-operations{}".format(BASE_URL, info_needed['href'])
         print("Attempting check-in...")
         confirmation = self.load_json_page(url, info_needed['body'])
-        if len(self.notifications) > 0:
-            self.send_notification(confirmation)
         return confirmation
-
-    def send_notification(self, checkindata):
-        if not checkindata['_links']:
-            print("Mobile boarding passes not eligible for this reservation")
-            return
-        # We don't want failure to send notification to cause the program to bomb out
-        # wrap this in a try block to gracefully fail
-        try:
-            info_needed = checkindata['_links']['boardingPasses']
-            url = "{}mobile-air-operations{}".format(BASE_URL, info_needed['href'])
-            mbpdata = self.load_json_page(url, info_needed['body'])
-            info_needed = mbpdata['_links']
-            url = "{}mobile-air-operations{}".format(BASE_URL, info_needed['href'])
-            print("Attempting to send boarding pass...")
-            for n in self.notifications:
-                body = info_needed['body'].copy()
-                body.update(n)
-                self.safe_request(url, body)
-        except KeyError:
-            print("Failure when sending boarding pass notification(s)")

--- a/tests/checkin_test.py
+++ b/tests/checkin_test.py
@@ -28,9 +28,6 @@ def test_reservation_lookup():
 
 @my_vcr.use_cassette()
 def test_checkin():
-    phone = southwest.Notifications.Phone('1234567890')
-    email = southwest.Notifications.Email('test@example.com')
-    r.notifications = [phone, email]
     try:
         r.checkin()
     except Exception:
@@ -39,9 +36,6 @@ def test_checkin():
 
 @my_vcr.use_cassette()
 def test_checkin_without_passes():
-    phone = southwest.Notifications.Phone('1234567890')
-    email = southwest.Notifications.Email('test@example.com')
-    r.notifications = [phone, email]
     try:
         r.checkin()
     except Exception:


### PR DESCRIPTION
Southwest mobile API no longer supports sending boarding passes by email or SMS.  Remove that functionality.