### PR TITLE
southwest: add channel id header

### DIFF
--- a/southwest/southwest.py
+++ b/southwest/southwest.py
@@ -29,7 +29,7 @@ class Reservation():
 
         USER_EXPERIENCE_KEY = str(uuid.uuid1()).upper()
         # Pulled from proxying the Southwest iOS App
-        return {'Host': 'mobile.southwest.com', 'Content-Type': 'application/json', 'X-API-Key': API_KEY, 'X-User-Experience-Id': USER_EXPERIENCE_KEY, 'Accept': '*/*'}
+        return {'Host': 'mobile.southwest.com', 'Content-Type': 'application/json', 'X-API-Key': API_KEY, 'X-User-Experience-Id': USER_EXPERIENCE_KEY, 'Accept': '*/*', 'X-Channel-ID': 'MWEB'}
 
     # You might ask yourself, "Why the hell does this exist?"
     # Basically, there sometimes appears a "hiccup" in Southwest where things


### PR DESCRIPTION
Today when trying to use the tool I noticed it was failing to pull the reservation information. It looks like the handling of the HTTP headers changed in the API as I was getting back a bad request error. After poking and trying a few different headers I noticed that the api call worked if I added a `x-channel-id` header. In my browser, it gets set to `MWEB` and that value worked in the script.

I'll let you know in about 12 hours if it works for the checkin call as well :sweat_smile: 