### PR TITLE
Resolves deprecated threading package fuction in 3.8+

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -80,7 +80,7 @@ def auto_checkin(reservation_number, first_name, last_name, verbose=False):
             break
         for t in threads:
             t.join(5)
-            if not t.isAlive():
+            if not t.is_alive():
                 threads.remove(t)
                 break
 


### PR DESCRIPTION
Minor fix, the `isAlive()` function of Thread objects is officially deprecated in favor of the snake-cased alternative, and will likely be removed in 3.9. Resolved in the attached commit.

Reference: [issue37804](https://bugs.python.org/issue37804)